### PR TITLE
chore: Bump deps (uom and approx)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 [dependencies]
 cfg-if = "1.0"
 num-traits = { version = "0.2", default_features = false }
-uom = { version = "0.30", features = ["autoconvert", "f32", "si"] }
+uom = { version = "0.31", features = ["autoconvert", "f32", "si"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 lazycell = "~1.3"
@@ -33,4 +33,4 @@ nix = "~0.23"
 
 [dev-dependencies]
 tempfile = "^3.0"
-approx = "0.3.2"
+approx = "0.5"


### PR DESCRIPTION
- `uom` to `0.31`
- `approx` to `0.5`

Tested, compiles fine.