### PR TITLE
Derive Deserialize/Serialize for State enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ num-traits = { version = "0.2", default_features = false }
 uom = { version = "0.30", features = ["autoconvert", "f32", "si"] }
 serde = { version = "1.0.136", features = ["derive"] }
 
+[dependencies.schemars]
+version = "0.8.8"
+features = ["preserve_order", "indexmap"]
+
 [target.'cfg(target_os = "linux")'.dependencies]
 lazycell = "~1.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ build = "build.rs"
 cfg-if = "1.0"
 num-traits = { version = "0.2", default_features = false }
 uom = { version = "0.30", features = ["autoconvert", "f32", "si"] }
+serde = { version = "1.0.136", features = ["derive"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 lazycell = "~1.3"

--- a/src/types/state.rs
+++ b/src/types/state.rs
@@ -1,14 +1,16 @@
 use std::fmt;
 use std::io;
 use std::str;
+use std::str::FromStr;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde::de::{Error, Unexpected};
 
 /// Possible battery state values.
 ///
 /// Unknown can mean either controller returned unknown,
 /// or not able to retrieve state due to some error.
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Serialize, schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum State {
     Unknown,
@@ -21,6 +23,12 @@ pub enum State {
     #[doc(hidden)]
     #[serde(skip)]
     __Nonexhaustive,
+}
+
+impl<'de> Deserialize<'de> for State {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+        String::deserialize(deserializer).and_then(|s| State::from_str(&s).map_err(|_| D::Error::invalid_value(Unexpected::Str(&s), &"State")))
+    }
 }
 
 impl str::FromStr for State {

--- a/src/types/state.rs
+++ b/src/types/state.rs
@@ -2,11 +2,13 @@ use std::fmt;
 use std::io;
 use std::str;
 
+use serde::{Deserialize, Serialize};
+
 /// Possible battery state values.
 ///
 /// Unknown can mean either controller returned unknown,
 /// or not able to retrieve state due to some error.
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize, Serialize)]
 pub enum State {
     Unknown,
     Charging,

--- a/src/types/state.rs
+++ b/src/types/state.rs
@@ -8,7 +8,8 @@ use serde::{Deserialize, Serialize};
 ///
 /// Unknown can mean either controller returned unknown,
 /// or not able to retrieve state due to some error.
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize, Serialize)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "lowercase")]
 pub enum State {
     Unknown,
     Charging,
@@ -18,6 +19,7 @@ pub enum State {
 
     // Awaiting for https://github.com/rust-lang/rust/issues/44109
     #[doc(hidden)]
+    #[serde(skip)]
     __Nonexhaustive,
 }
 


### PR DESCRIPTION
This MR adds the crates `serde` and `schemars` to allow serialization/deserialization and schema generation respectively for configuring the Starship battery module using the `State` enum (see starship/starship#3849).

I'm unsure about the error message when the deserialization fails for an invalid enum value, I'd appreciate some feedback regarding that.
