### PR TITLE
refactor!: rework ci & code cleanup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  labels:
+  - "\U0001F4E6 dependencies"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  labels:
+  - "\U0001F4E6 dependencies"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,125 +2,125 @@ on: [push, pull_request]
 
 name: Continuous integration
 
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+  RUSTUP_MAX_RETRIES: 10
+
 jobs:
-  linux:
-    name: Linux
-    runs-on: ubuntu-latest
+  test:
+    name: Test
     strategy:
       matrix:
         toolchain:
           - stable
-          - 1.46.0  # MSRV
-        arch:
+          - 1.46.0 # MSRV
+        target:
           - i686-unknown-linux-gnu
           - x86_64-unknown-linux-gnu
-    steps:
-      - uses: actions/checkout@master
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          target: ${{ matrix.arch }}
-          override: true
-
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: build
-          args: --target ${{ matrix.arch }}
-
-      - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: test
-          args: --target ${{ matrix.arch }}
-
-      - name: Run clippy
-        if: matrix.toolchain == 'stable'
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: clippy
-          args: --target ${{ matrix.arch }} -- -D warnings
-
-  windows:
-    name: Windows
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        toolchain:
-          - stable
-          - 1.46.0  # MSRV
-        arch:
+          - x86_64-unknown-linux-musl
           - i686-pc-windows-msvc
           - x86_64-pc-windows-msvc
+          - x86_64-apple-darwin
+        include:
+          - target: i686-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: i686-pc-windows-msvc
+            os: windows-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@master
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3.0.2
+      - uses: actions-rs/toolchain@v1.0.6
         with:
           toolchain: ${{ matrix.toolchain }}
-          target: ${{ matrix.arch }}
+          target: ${{ matrix.target }}
           override: true
 
+      - uses: Swatinem/rust-cache@v1.3.0
+
       - name: Build
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@v1.0.1
         with:
           use-cross: true
           command: build
-          args: --target ${{ matrix.arch }}
+          args: --target ${{ matrix.target }} --all-features --all-targets
 
       - name: Run tests
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@v1.0.1
         with:
           use-cross: true
           command: test
-          args: --target ${{ matrix.arch }}
+          args: --target ${{ matrix.target }} --all-features --all-targets
 
       - name: Run clippy
         if: matrix.toolchain == 'stable'
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@v1.0.1
         with:
           use-cross: true
           command: clippy
-          args: --target ${{ matrix.arch }} -- -D warnings
+          args: --target ${{ matrix.target }} -- -D clippy::all
 
-  macos:
-    name: macOS
-    runs-on: macOS-latest
+  build_only:
+    name: Test [Build only]
     strategy:
       matrix:
         toolchain:
           - stable
-          - 1.46.0  # MSRV
-        arch:
-          - x86_64-apple-darwin
+          - 1.46.0 # MSRV
+        target:
+          - x86_64-unknown-freebsd
+          - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
+          - aarch64-pc-windows-msvc
+          - aarch64-apple-darwin
+        include:
+          - target: x86_64-unknown-freebsd
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+        exclude:
+          - target: aarch64-apple-darwin
+            toolchain: 1.46.0
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@master
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3.0.2
+      # FreeBSD requires latest cross
+      - run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - uses: actions-rs/toolchain@v1.0.6
         with:
           toolchain: ${{ matrix.toolchain }}
-          target: ${{ matrix.arch }}
+          target: ${{ matrix.target }}
           override: true
 
+      - uses: Swatinem/rust-cache@v1.3.0
+
       - name: Build
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@v1.0.1
         with:
           use-cross: true
           command: build
-          args: --target ${{ matrix.arch }}
-
-      - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: test
-          args: --target ${{ matrix.arch }}
+          args: --target ${{ matrix.target }}
 
       - name: Run clippy
         if: matrix.toolchain == 'stable'
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@v1.0.1
         with:
           use-cross: true
           command: clippy
-          args: --target ${{ matrix.arch }} -- -D warnings
+          args: --target ${{ matrix.target }} -- -D clippy::all

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: Deploy
+on:
+  push:
+    branches:
+      - master
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+  RUSTUP_MAX_RETRIES: 10
+
+jobs:
+  # Update release PR
+  release_please:
+    name: Release Please
+    runs-on: ubuntu-latest
+    if: github.repository == 'starship/rust-battery'
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: rust
+
+  # Publish starship-battery to Crates.io
+  cargo_publish:
+    name: Publish Cargo Package
+    runs-on: ubuntu-latest
+    needs: release_please
+    if: ${{ needs.release_please.outputs.release_created == 'true' }}
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@v3.0.2
+
+      - name: Setup | Rust
+        uses: actions-rs/toolchain@v1.0.7
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Build | Publish
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 on:
   push:
     branches:
-      - master
+      - main
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10

--- a/.github/workflows/merge-dependabot.yml
+++ b/.github/workflows/merge-dependabot.yml
@@ -1,0 +1,15 @@
+name: Auto-merge Dependabot PRs
+on:
+  schedule:
+    - cron: "0 * * * *"
+jobs:
+  auto_merge:
+    if: (github.event_name == 'schedule' && github.repository == 'starship/rust-battery') || (github.event_name != 'schedule')
+    name: Auto-merge Dependabot PRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: akheron/dependabot-cron-action@d020867c009553e279f0200b621459444828a9b0
+        with:
+          token: ${{ secrets.DEPENDABOT_GITHUB_API_TOKEN }}
+          auto-merge: "minor"
+          merge-method: "squash"

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,29 @@
+name: Security audit
+on:
+  pull_request:
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+  push:
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+  schedule:
+    - cron: "0 0 * * *"
+jobs:
+  security_audit:
+    if: (github.event_name == 'schedule' && github.repository == 'starship/rust-battery') || (github.event_name != 'schedule')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@v3
+      - name: Setup | Rust
+        uses: actions-rs/toolchain@v1.0.7
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+      - name: Test | Security Audit
+        uses: actions-rs/audit-check@v1.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 [dependencies]
 cfg-if = "1.0"
 num-traits = { version = "0.2", default_features = false }
-uom = { version = "0.30", features = ["autoconvert", "f32", "si"] }
+uom = { version = "0.32", features = ["autoconvert", "f32", "si"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 lazycell = "~1.3"
@@ -22,15 +22,15 @@ lazycell = "~1.3"
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 libc = "^0.2"
 mach = "^0.3"
-core-foundation = "~0.7"
+core-foundation = "~0.9"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version ="~0.3", features = ["impl-default", "devguid", "winbase", "ioapiset", "ntdef", "setupapi", "handleapi", "errhandlingapi", "winerror"] }
 
 [target.'cfg(any(target_os = "dragonfly", target_os = "freebsd"))'.dependencies]
 libc = "~0.2"
-nix = "~0.23"
+nix = { version = "~0.24", default-features = false, features = ["ioctl"] }
 
 [dev-dependencies]
 tempfile = "^3.0"
-approx = "0.3.2"
+approx = "0.5.1"

--- a/README.md
+++ b/README.md
@@ -73,17 +73,8 @@ fn main() -> Result<(), battery::Error> {
 }
 ```
 
-See the `battery/examples/` folder in the [repository](https://github.com/svartalf/rust-battery/blob/master/battery/examples/simple.rs)
+See the `battery/examples/` folder in the [repository](https://github.com/starship/rust-battery/blob/main/battery/examples/simple.rs)
 for additional examples.
-
-## FFI bindings
-
-Experimental [battery-ffi](https://crates.io/crates/battery-ffi) crate provides the FFI bindings to the `battery` crate,
-so it can be used with other languages, such as C, Python or NodeJS.
-
-Check its [README](https://github.com/svartalf/rust-battery/tree/master/battery-ffi)
-and [documentation](https://docs.rs/battery-ffi) for details.
-
 ## Users
 
 This an incomplete list of the `battery` crate users. If you are using it too,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! ## Examples
 //!
 //! For a quick example see the [Manager](struct.Manager.html) type documentation
-//! or [`simple.rs`](https://github.com/svartalf/rust-battery/blob/master/battery/examples/simple.rs)
+//! or [`simple.rs`](https://github.com/starship/rust-battery/blob/main/battery/examples/simple.rs)
 //! file in the `examples/` folder.
 //!
 //! [battop](https://crates.io/crates/battop) crate is using this library as a knowledge source,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,6 @@
 #![deny(unused)]
 #![deny(unstable_features)]
 #![deny(bare_trait_objects)]
-#![allow(clippy::manual_non_exhaustive)] // MSRV is 1.36
 #![doc(html_root_url = "https://docs.rs/starship-battery/0.7.9")]
 
 #[macro_use]

--- a/src/platform/darwin/device.rs
+++ b/src/platform/darwin/device.rs
@@ -107,9 +107,7 @@ where
     T: DataSource,
 {
     fn from(ds: T) -> IoKitDevice {
-        IoKitDevice {
-            source: Box::new(ds),
-        }
+        IoKitDevice { source: Box::new(ds) }
     }
 }
 

--- a/src/platform/darwin/iokit/power_source.rs
+++ b/src/platform/darwin/iokit/power_source.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::redundant_static_lifetimes)]
-
 use std::fmt;
 use std::i32;
 
@@ -16,20 +14,20 @@ use crate::{Error, Result};
 
 type Properties = CFDictionary<CFString, CFType>;
 
-static FULLY_CHARGED_KEY: &'static str = "FullyCharged";
-static EXTERNAL_CONNECTED_KEY: &'static str = "ExternalConnected";
-static IS_CHARGING_KEY: &'static str = "IsCharging";
-static VOLTAGE_KEY: &'static str = "Voltage";
-static AMPERAGE_KEY: &'static str = "Amperage";
-static DESIGN_CAPACITY_KEY: &'static str = "DesignCapacity";
-static MAX_CAPACITY_KEY: &'static str = "MaxCapacity";
-static CURRENT_CAPACITY_KEY: &'static str = "CurrentCapacity";
-static TEMPERATURE_KEY: &'static str = "Temperature";
-static CYCLE_COUNT_KEY: &'static str = "CycleCount";
-static TIME_REMAINING_KEY: &'static str = "TimeRemaining";
-static MANUFACTURER_KEY: &'static str = "Manufacturer";
-static DEVICE_NAME_KEY: &'static str = "DeviceName";
-static BATTERY_SERIAL_NUMBER_KEY: &'static str = "BatterySerialNumber";
+static FULLY_CHARGED_KEY: &str = "FullyCharged";
+static EXTERNAL_CONNECTED_KEY: &str = "ExternalConnected";
+static IS_CHARGING_KEY: &str = "IsCharging";
+static VOLTAGE_KEY: &str = "Voltage";
+static AMPERAGE_KEY: &str = "Amperage";
+static DESIGN_CAPACITY_KEY: &str = "DesignCapacity";
+static MAX_CAPACITY_KEY: &str = "MaxCapacity";
+static CURRENT_CAPACITY_KEY: &str = "CurrentCapacity";
+static TEMPERATURE_KEY: &str = "Temperature";
+static CYCLE_COUNT_KEY: &str = "CycleCount";
+static TIME_REMAINING_KEY: &str = "TimeRemaining";
+static MANUFACTURER_KEY: &str = "Manufacturer";
+static DEVICE_NAME_KEY: &str = "DeviceName";
+static BATTERY_SERIAL_NUMBER_KEY: &str = "BatterySerialNumber";
 
 #[derive(Debug)]
 pub struct InstantData {
@@ -63,9 +61,13 @@ impl InstantData {
                 .map(|value| celsius!(value as f32 / 100.0))
                 .ok(),
             cycle_count: Self::get_u32(props, CYCLE_COUNT_KEY).ok(),
-            time_remaining: Self::get_i32(props, TIME_REMAINING_KEY)
-                .ok()
-                .and_then(|val| if val == i32::MAX { None } else { Some(minute!(val)) }),
+            time_remaining: Self::get_i32(props, TIME_REMAINING_KEY).ok().and_then(|val| {
+                if val == i32::MAX {
+                    None
+                } else {
+                    Some(minute!(val))
+                }
+            }),
         })
     }
 

--- a/src/platform/freebsd/acpi.rs
+++ b/src/platform/freebsd/acpi.rs
@@ -1,5 +1,5 @@
-// https://github.com/freebsd/freebsd/blob/master/sys/dev/acpica/acpiio.h
-// https://github.com/freebsd/freebsd/blob/master/sys/dev/acpica/acpi_battery.c
+// https://github.com/freebsd/freebsd-src/blob/main/sys/dev/acpica/acpiio.h
+// https://github.com/freebsd/freebsd-src/blob/main/sys/dev/acpica/acpi_battery.c
 
 use std::default::Default;
 use std::ffi::CStr;

--- a/src/platform/freebsd/acpi.rs
+++ b/src/platform/freebsd/acpi.rs
@@ -118,7 +118,7 @@ impl AcpiBif {
             None => return None,
         };
 
-        match CStr::from_bytes_with_nul(&striped) {
+        match CStr::from_bytes_with_nul(striped) {
             Ok(cstr) => Some(cstr.to_string_lossy().to_string()),
             Err(_) => None,
         }
@@ -221,7 +221,11 @@ impl AcpiDevice {
         };
         let info = unsafe { arg.bif };
 
-        if info.is_valid() { Ok(Some(info)) } else { Ok(None) }
+        if info.is_valid() {
+            Ok(Some(info))
+        } else {
+            Ok(None)
+        }
     }
 
     /// # Returns
@@ -237,7 +241,11 @@ impl AcpiDevice {
         };
         let info = unsafe { arg.bst };
 
-        if info.is_valid() { Ok(Some(info)) } else { Ok(None) }
+        if info.is_valid() {
+            Ok(Some(info))
+        } else {
+            Ok(None)
+        }
     }
 }
 

--- a/src/platform/linux/iterator.rs
+++ b/src/platform/linux/iterator.rs
@@ -19,10 +19,7 @@ impl BatteryIterator for SysFsIterator {
     fn new(manager: Rc<Self::Manager>) -> Result<Self> {
         let entries = fs::read_dir(manager.path())?;
 
-        Ok(SysFsIterator {
-            manager,
-            entries,
-        })
+        Ok(SysFsIterator { manager, entries })
     }
 }
 

--- a/src/platform/linux/manager.rs
+++ b/src/platform/linux/manager.rs
@@ -5,8 +5,7 @@ use super::iterator::SysFsIterator;
 use crate::platform::traits::*;
 use crate::Result;
 
-#[allow(clippy::redundant_static_lifetimes)]
-static SYSFS_ROOT: &'static str = "/sys/class/power_supply";
+static SYSFS_ROOT: &str = "/sys/class/power_supply";
 
 #[derive(Debug)]
 pub struct SysFsManager {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -25,7 +25,7 @@ cfg_if! {
         pub type Device = freebsd::IoCtlDevice;
     } else {
         compile_error!("Support for this target OS is not implemented yet!\n \
-            You may want to create an issue: https://github.com/svartalf/rust-battery/issues/new");
+            You may want to create an issue: https://github.com/starship/rust-battery/issues/new");
     }
 }
 

--- a/src/platform/windows/ffi/ioctl/info.rs
+++ b/src/platform/windows/ffi/ioctl/info.rs
@@ -33,14 +33,8 @@ impl Default for BATTERY_INFORMATION {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct BatteryInformation(BATTERY_INFORMATION);
-
-impl Default for BatteryInformation {
-    fn default() -> Self {
-        BatteryInformation(BATTERY_INFORMATION::default())
-    }
-}
 
 impl ops::Deref for BatteryInformation {
     type Target = BATTERY_INFORMATION;

--- a/src/platform/windows/ffi/ioctl/query_info.rs
+++ b/src/platform/windows/ffi/ioctl/query_info.rs
@@ -23,18 +23,12 @@ impl Default for BATTERY_QUERY_INFORMATION {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct BatteryQueryInformation(BATTERY_QUERY_INFORMATION);
 
 impl BatteryQueryInformation {
     pub fn battery_tag(&self) -> ntdef::ULONG {
         self.0.BatteryTag
-    }
-}
-
-impl Default for BatteryQueryInformation {
-    fn default() -> Self {
-        BatteryQueryInformation(BATTERY_QUERY_INFORMATION::default())
     }
 }
 

--- a/src/platform/windows/ffi/ioctl/status.rs
+++ b/src/platform/windows/ffi/ioctl/status.rs
@@ -41,14 +41,8 @@ impl Default for BATTERY_STATUS {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct BatteryStatus(BATTERY_STATUS);
-
-impl Default for BatteryStatus {
-    fn default() -> Self {
-        BatteryStatus(BATTERY_STATUS::default())
-    }
-}
 
 impl ops::Deref for BatteryStatus {
     type Target = BATTERY_STATUS;

--- a/src/platform/windows/ffi/ioctl/wait_status.rs
+++ b/src/platform/windows/ffi/ioctl/wait_status.rs
@@ -23,14 +23,8 @@ impl Default for BATTERY_WAIT_STATUS {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct BatteryWaitStatus(BATTERY_WAIT_STATUS);
-
-impl Default for BatteryWaitStatus {
-    fn default() -> Self {
-        BatteryWaitStatus(BATTERY_WAIT_STATUS::default())
-    }
-}
 
 impl ops::Deref for BatteryWaitStatus {
     type Target = BATTERY_WAIT_STATUS;

--- a/src/platform/windows/ffi/mod.rs
+++ b/src/platform/windows/ffi/mod.rs
@@ -67,7 +67,11 @@ impl DeviceIterator {
         };
 
         // TODO: Add trace
-        if result == 0 { Err(get_last_error()) } else { Ok(data) }
+        if result == 0 {
+            Err(get_last_error())
+        } else {
+            Ok(data)
+        }
     }
 
     fn get_interface_detail(&self, data: &mut setupapi::SP_DEVICE_INTERFACE_DATA) -> io::Result<InterfaceDetailData> {
@@ -228,7 +232,11 @@ impl DeviceHandle {
             )
         };
 
-        if res == 0 { Err(get_last_error()) } else { Ok(out) }
+        if res == 0 {
+            Err(get_last_error())
+        } else {
+            Ok(out)
+        }
     }
 
     pub fn status(&mut self) -> io::Result<ioctl::BatteryStatus> {
@@ -253,7 +261,11 @@ impl DeviceHandle {
             )
         };
 
-        if res == 0 { Err(get_last_error()) } else { Ok(out) }
+        if res == 0 {
+            Err(get_last_error())
+        } else {
+            Ok(out)
+        }
     }
 
     // 10ths of a degree Kelvin (or decikelvin)
@@ -280,7 +292,11 @@ impl DeviceHandle {
             )
         };
 
-        if res == 0 { Err(get_last_error()) } else { Ok(out) }
+        if res == 0 {
+            Err(get_last_error())
+        } else {
+            Ok(out)
+        }
     }
 
     pub fn device_name(&mut self) -> io::Result<String> {

--- a/src/platform/windows/iterator.rs
+++ b/src/platform/windows/iterator.rs
@@ -40,10 +40,7 @@ impl BatteryIterator for PowerIterator {
 
     fn new(manager: Rc<Self::Manager>) -> Result<Self> {
         let inner = ffi::DeviceIterator::new()?;
-        Ok(Self {
-            manager,
-            inner,
-        })
+        Ok(Self { manager, inner })
     }
 }
 

--- a/src/types/manager.rs
+++ b/src/types/manager.rs
@@ -32,9 +32,7 @@ impl Manager {
     pub fn new() -> Result<Manager> {
         let inner = PlatformManager::new()?;
 
-        Ok(Manager {
-            inner: Rc::new(inner),
-        })
+        Ok(Manager { inner: Rc::new(inner) })
     }
 
     /// Returns an iterator over available batteries.

--- a/src/types/state.rs
+++ b/src/types/state.rs
@@ -13,10 +13,6 @@ pub enum State {
     Discharging,
     Empty,
     Full,
-
-    // Awaiting for https://github.com/rust-lang/rust/issues/44109
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl str::FromStr for State {
@@ -46,7 +42,6 @@ impl fmt::Display for State {
             State::Discharging => "discharging",
             State::Empty => "empty",
             State::Full => "full",
-            _ => "unknown",
         };
 
         write!(f, "{}", display)

--- a/src/types/technology.rs
+++ b/src/types/technology.rs
@@ -5,6 +5,7 @@ use crate::Error;
 
 /// Possible battery technologies.
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[non_exhaustive]
 pub enum Technology {
     Unknown,
     LithiumIon,
@@ -15,10 +16,6 @@ pub enum Technology {
     NickelZinc,
     LithiumIronPhosphate,
     RechargeableAlkalineManganese,
-
-    // Awaiting for https://github.com/rust-lang/rust/issues/44109
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl str::FromStr for Technology {
@@ -59,7 +56,6 @@ impl fmt::Display for Technology {
             Technology::NickelZinc => "nickel-zinc",
             Technology::LithiumIronPhosphate => "lithium-iron-phosphate",
             Technology::RechargeableAlkalineManganese => "rechargeable-alkaline-manganese",
-            _ => "unknown",
         };
 
         write!(f, "{}", display)


### PR DESCRIPTION
This PR includes:

- release-please and cargo publishing
- (Build) testing for more platforms (including FreeBSD, musl and ARM)
- Upgraded dependencies
- Depdendabot
- Clippy fixes
- removal of disabled clippy lints
- removal of deprecated std-library item (`mem::uninitialized`)
- add audit-check to CI

Marked as a breaking change because this includes the non-exhaustive removal from #2.

@matchai You will need to add secrets for cargo and Dependabot.