### PR TITLE
remove unaligned references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.46.0 # MSRV
+          - 1.51.0 # MSRV
         target:
           - i686-unknown-linux-gnu
           - x86_64-unknown-linux-gnu
@@ -75,7 +75,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.46.0 # MSRV
+          - 1.51.0 # MSRV
         target:
           - x86_64-unknown-freebsd
           - aarch64-unknown-linux-gnu
@@ -95,7 +95,7 @@ jobs:
             os: macos-latest
         exclude:
           - target: aarch64-apple-darwin
-            toolchain: 1.46.0
+            toolchain: 1.51.0
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3.0.2

--- a/README.md
+++ b/README.md
@@ -3,24 +3,24 @@
 [![Latest Version](https://img.shields.io/crates/v/starship-battery.svg)](https://crates.io/crates/starship-battery)
 [![Latest Version](https://docs.rs/starship-battery/badge.svg)](https://docs.rs/starship-battery)
 [![Build Status](https://github.com/starship/rust-battery/workflows/Continuous%20integration/badge.svg)](https://github.com/starship/rust-battery/actions?workflow=Continuous+integration)
-![Minimum rustc version](https://img.shields.io/badge/rustc-1.46+-yellow.svg)
+![Minimum rustc version](https://img.shields.io/badge/rustc-1.51+-yellow.svg)
 ![ISC licensed](https://img.shields.io/badge/license-ISC-blue.svg)
 
 > Rust crate providing cross-platform information about the notebook batteries.
 
 ## Table of contents
 
- * [Overview](#overview)
- * [Supported platforms](#supported-platforms)
- * [Install](#install)
- * [Examples](#examples)
- * [FFI bindings](#ffi-bindings)
- * [Users](#users)
- * [License](#license)
- * [Donations](#donations)
- * [Contributors](#contributors)
- * [Backers](#backers)
- * [Sponsors](#sponsors)
+* [Overview](#overview)
+* [Supported platforms](#supported-platforms)
+* [Install](#install)
+* [Examples](#examples)
+* [FFI bindings](#ffi-bindings)
+* [Users](#users)
+* [License](#license)
+* [Donations](#donations)
+* [Contributors](#contributors)
+* [Backers](#backers)
+* [Sponsors](#sponsors)
 
 ## Overview
 
@@ -44,7 +44,7 @@ might be automatically rejected by Apple based on that fact. Use it on your own 
 
 ## Install
 
-As a prerequisite, `battery` crate requires at least Rustc version **1.46** or greater.
+As a prerequisite, `battery` crate requires at least Rustc version **1.51** or greater.
 
 Add the following line into a `Cargo.toml`:
 
@@ -75,6 +75,7 @@ fn main() -> Result<(), battery::Error> {
 
 See the `battery/examples/` folder in the [repository](https://github.com/starship/rust-battery/blob/main/battery/examples/simple.rs)
 for additional examples.
+
 ## Users
 
 This an incomplete list of the `battery` crate users. If you are using it too,


### PR DESCRIPTION
As of Rust 1.62.0, compiling with the `i686-pc-windows-msvc` target gives the following warning:

```bash
warning: the following packages contain code that will be rejected by a future version of Rust: starship-battery v0.7.9
(...)
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 30`      
```

Running the suggested command gives the following:

```bash
The package `starship-battery v0.7.9 (C:\Users\Clement\Documents\GitHub\rust-battery)` currently triggers the following future incompatibility lints:
> warning: reference to packed field is unaligned
>    --> src\platform\windows\ffi\mod.rs:120:36
>     |
> 120 |         let device_path = unsafe { (***pdidd).DevicePath.as_ptr() };
>     |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>     |
> note: the lint level is defined here
>    --> src\platform\windows\ffi\mod.rs:1:10
>     |
> 1   | #![allow(unaligned_references)]
>     |          ^^^^^^^^^^^^^^^^^^^^
>     = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
>     = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
>     = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
>     = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
>
> warning: reference to packed field is unaligned
>    --> src\platform\windows\ffi\mod.rs:150:17
>     |
> 150 |                 &mut query.BatteryTag as *mut _ as minwindef::LPVOID,
>     |                 ^^^^^^^^^^^^^^^^^^^^^
>     |
> note: the lint level is defined here
>    --> src\platform\windows\ffi\mod.rs:1:10
>     |
> 1   | #![allow(unaligned_references)]
>     |          ^^^^^^^^^^^^^^^^^^^^
>     = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
>     = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
>     = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
>     = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
>
```
which refers to https://github.com/rust-lang/rust/issues/82523.

This PR just changes out the unaligned references with the suggested fixes to silence the warning. I'm not 100% certain if this is the correct way of doing it and would appreciate a check by someone who's better versed at working with this stuff, but it does seem to work if I run the simple example included with the repo on my laptop.