### PR TITLE
ci: avoid releasing v1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: rust
+          bump-minor-pre-major: true
 
   # Publish starship-battery to Crates.io
   cargo_publish:


### PR DESCRIPTION
I think it would be better not to release `v1.0.0` for the next release just yet. Configure `release-please` to treat pre-v1 breaking changes as minor-bumps (#10).