### PR TITLE
feat: make structs thread-safe

### DIFF
--- a/src/platform/darwin/iterator.rs
+++ b/src/platform/darwin/iterator.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::{iokit, IoKitDevice, IoKitManager};
 use crate::platform::traits::BatteryIterator;
@@ -7,7 +7,7 @@ use crate::Result;
 
 pub struct IoKitIterator {
     #[allow(dead_code)]
-    manager: Rc<IoKitManager>,
+    manager: Arc<IoKitManager>,
     inner: iokit::IoIterator,
 }
 
@@ -33,7 +33,7 @@ impl BatteryIterator for IoKitIterator {
     type Manager = IoKitManager;
     type Device = IoKitDevice;
 
-    fn new(manager: Rc<Self::Manager>) -> Result<Self> {
+    fn new(manager: Arc<Self::Manager>) -> Result<Self> {
         let services = manager.get_services()?;
 
         Ok(Self {

--- a/src/platform/freebsd/iterator.rs
+++ b/src/platform/freebsd/iterator.rs
@@ -1,13 +1,13 @@
 use std::fmt;
 use std::ops::Range;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::{IoCtlDevice, IoCtlManager};
 use crate::platform::traits::BatteryIterator;
 use crate::Result;
 
 pub struct IoCtlIterator {
-    manager: Rc<IoCtlManager>,
+    manager: Arc<IoCtlManager>,
     range: Range<libc::c_int>,
 }
 
@@ -46,7 +46,7 @@ impl BatteryIterator for IoCtlIterator {
     type Manager = IoCtlManager;
     type Device = IoCtlDevice;
 
-    fn new(manager: Rc<Self::Manager>) -> Result<Self> {
+    fn new(manager: Arc<Self::Manager>) -> Result<Self> {
         let batteries = manager.count()?;
 
         Ok(Self {

--- a/src/platform/linux/iterator.rs
+++ b/src/platform/linux/iterator.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::fs::{self, ReadDir};
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::{SysFsDevice, SysFsManager};
 use crate::platform::traits::*;
@@ -8,7 +8,7 @@ use crate::Result;
 
 pub struct SysFsIterator {
     #[allow(dead_code)]
-    manager: Rc<SysFsManager>,
+    manager: Arc<SysFsManager>,
     entries: ReadDir,
 }
 
@@ -16,7 +16,7 @@ impl BatteryIterator for SysFsIterator {
     type Manager = SysFsManager;
     type Device = SysFsDevice;
 
-    fn new(manager: Rc<Self::Manager>) -> Result<Self> {
+    fn new(manager: Arc<Self::Manager>) -> Result<Self> {
         let entries = fs::read_dir(manager.path())?;
 
         Ok(SysFsIterator { manager, entries })

--- a/src/platform/traits.rs
+++ b/src/platform/traits.rs
@@ -1,7 +1,7 @@
 //! Platform-specific types are required to implement the following traits.
 
 use std::fmt::Debug;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use num_traits::identities::Zero;
 use uom::si::time::{day, hour};
@@ -27,7 +27,7 @@ pub trait BatteryIterator: Iterator<Item = Result<<Self as BatteryIterator>::Dev
     ///
     /// Implemented `next()` for `<Self as Iterator>` must preload all needed battery data
     /// in this method, because `BatteryDevice` methods are infallible.
-    fn new(manager: Rc<Self::Manager>) -> Result<Self>;
+    fn new(manager: Arc<Self::Manager>) -> Result<Self>;
 }
 
 /// Underline type for `Battery`, different for each supported platform.

--- a/src/platform/windows/iterator.rs
+++ b/src/platform/windows/iterator.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::{ffi, PowerDevice, PowerManager};
 use crate::platform::traits::BatteryIterator;
@@ -7,7 +7,7 @@ use crate::Result;
 
 pub struct PowerIterator {
     #[allow(dead_code)]
-    manager: Rc<PowerManager>,
+    manager: Arc<PowerManager>,
     inner: ffi::DeviceIterator,
 }
 
@@ -38,7 +38,7 @@ impl BatteryIterator for PowerIterator {
     type Manager = PowerManager;
     type Device = PowerDevice;
 
-    fn new(manager: Rc<Self::Manager>) -> Result<Self> {
+    fn new(manager: Arc<Self::Manager>) -> Result<Self> {
         let inner = ffi::DeviceIterator::new()?;
         Ok(Self { manager, inner })
     }

--- a/src/types/manager.rs
+++ b/src/types/manager.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::platform::traits::*;
 use crate::platform::Iterator as PlatformIterator;
@@ -24,7 +24,7 @@ use crate::{Batteries, Battery, Result};
 ///
 /// [batteries]: struct.Battery.html
 pub struct Manager {
-    inner: Rc<PlatformManager>,
+    inner: Arc<PlatformManager>,
 }
 
 impl Manager {
@@ -32,7 +32,7 @@ impl Manager {
     pub fn new() -> Result<Manager> {
         let inner = PlatformManager::new()?;
 
-        Ok(Manager { inner: Rc::new(inner) })
+        Ok(Manager { inner: Arc::new(inner) })
     }
 
     /// Returns an iterator over available batteries.


### PR DESCRIPTION
replacing all instances of Rc with Arc allows references to the battery manager to exist while communicating with other threads. see also:
https://users.rust-lang.org/t/tokio-std-mpsc-future-cannot-be-sent-between-threads-safely & https://gitlab.com/thomas351/rust-influxdb-udp-logger/-/blob/main/src/main.rs#L284