### PR TITLE
fix: bump msrv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,6 @@ jobs:
             os: windows-latest
           - target: aarch64-apple-darwin
             os: macos-latest
-        exclude:
-          - target: aarch64-apple-darwin
-            toolchain: 1.54.0
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.51.0 # MSRV
+          - 1.54.0 # MSRV
         target:
           - i686-unknown-linux-gnu
           - x86_64-unknown-linux-gnu
@@ -75,7 +75,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.51.0 # MSRV
+          - 1.54.0 # MSRV
         target:
           - x86_64-unknown-freebsd
           - aarch64-unknown-linux-gnu
@@ -95,7 +95,7 @@ jobs:
             os: macos-latest
         exclude:
           - target: aarch64-apple-darwin
-            toolchain: 1.51.0
+            toolchain: 1.54.0
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
           target: ${{ matrix.target }}
           override: true
 
-      - uses: Swatinem/rust-cache@v2.0.1
+      - uses: Swatinem/rust-cache@v2.2.0
+        with:
+          key: ${{ matrix.target }}
 
       - name: Build
         uses: actions-rs/cargo@v1.0.3
@@ -105,7 +107,9 @@ jobs:
           target: ${{ matrix.target }}
           override: true
 
-      - uses: Swatinem/rust-cache@v2.0.1
+      - uses: Swatinem/rust-cache@v2.2.0
+        with:
+          key: ${{ matrix.target }}
 
       - name: Build
         uses: actions-rs/cargo@v1.0.3

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Latest Version](https://img.shields.io/crates/v/starship-battery.svg)](https://crates.io/crates/starship-battery)
 [![Latest Version](https://docs.rs/starship-battery/badge.svg)](https://docs.rs/starship-battery)
 [![Build Status](https://github.com/starship/rust-battery/workflows/Continuous%20integration/badge.svg)](https://github.com/starship/rust-battery/actions?workflow=Continuous+integration)
-![Minimum rustc version](https://img.shields.io/badge/rustc-1.51+-yellow.svg)
+![Minimum rustc version](https://img.shields.io/badge/rustc-1.54+-yellow.svg)
 ![ISC licensed](https://img.shields.io/badge/license-ISC-blue.svg)
 
 > Rust crate providing cross-platform information about the notebook batteries.
@@ -44,7 +44,7 @@ might be automatically rejected by Apple based on that fact. Use it on your own 
 
 ## Install
 
-As a prerequisite, `battery` crate requires at least Rustc version **1.51** or greater.
+As a prerequisite, `battery` crate requires at least Rustc version **1.54** or greater.
 
 Add the following line into a `Cargo.toml`:
 

--- a/src/units.rs
+++ b/src/units.rs
@@ -263,13 +263,7 @@ pub(crate) trait Bound: Sized {
 impl Bound for Ratio {
     #[inline]
     fn into_bounded(mut self) -> Self {
-        if self.value < 0.0 {
-            self.value = 0.0;
-        }
-
-        if self.value > 1.0 {
-            self.value = 1.0;
-        }
+        self.value = self.value.clamp(0.0, 1.0);
 
         self
     }


### PR DESCRIPTION
v1.54.0 is the first versions that builds on macOS for me.

Related: https://github.com/starship/rust-battery/pull/21#issuecomment-1364497388