### PR TITLE
fix: bump msrv further

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.54.0 # MSRV
+          - 1.56.0 # MSRV
         target:
           - i686-unknown-linux-gnu
           - x86_64-unknown-linux-gnu
@@ -77,7 +77,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.54.0 # MSRV
+          - 1.56.0 # MSRV
         target:
           - x86_64-unknown-freebsd
           - aarch64-unknown-linux-gnu

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["os"]
 keywords = ["battery", "linux", "macos", "windows", "freebsd"]
 license = "ISC"
 build = "build.rs"
+rust-version = "1.56"
 
 [dependencies]
 cfg-if = "1.0"


### PR DESCRIPTION
Rust 1.56 isn't much higher and supports `rust-version` which stops clippy from suggesting msrv-breaking changes.