### PR TITLE
fix: replace `mach` with `mach2` fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ lazycell = "~1.3"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 libc = "^0.2"
-mach = "^0.3"
+mach = { version = "^0.4", package = "mach2" }
 core-foundation = "~0.9"
 
 [target.'cfg(target_os = "windows")'.dependencies]


### PR DESCRIPTION
`mach` is unmaintained. `mach2` is the suggested replacement.