### PR TITLE
fix: use correct data source for querying max capacity on arm64-macOS

### DIFF
--- a/src/platform/darwin/iokit/power_source.rs
+++ b/src/platform/darwin/iokit/power_source.rs
@@ -20,8 +20,14 @@ static IS_CHARGING_KEY: &str = "IsCharging";
 static VOLTAGE_KEY: &str = "Voltage";
 static AMPERAGE_KEY: &str = "Amperage";
 static DESIGN_CAPACITY_KEY: &str = "DesignCapacity";
-static MAX_CAPACITY_KEY: &str = "MaxCapacity";
-static CURRENT_CAPACITY_KEY: &str = "CurrentCapacity";
+
+// aarch64 means M series chips.
+// MaxCapacity and CurrentCapacity returns percentage in M series chips, ranging from 1 to 100.
+// Have to use AppleRawMaxCapacity and AppleRawCurrentCapacity to get actual mAh.
+// No idea if Intel-chip mac need to be changed as well.
+static MAX_CAPACITY_KEY: &str = if cfg!(target_arch = "aarch64") {"AppleRawMaxCapacity"} else {"MaxCapacity"};
+static CURRENT_CAPACITY_KEY: &str = if cfg!(target_arch = "aarch64") {"AppleRawCurrentCapacity"} else {"CurrentCapacity"};
+
 static TEMPERATURE_KEY: &str = "Temperature";
 static CYCLE_COUNT_KEY: &str = "CycleCount";
 static TIME_REMAINING_KEY: &str = "TimeRemaining";


### PR DESCRIPTION
"MaxCapacity" and "CurrentCapacity" returns value in percentage, range from 0 to 100, which causes bug in calculating current capacity and max capacity.

I have no idea if this bug affects Intel Mac too, so my modification is a bit conservative: only fix it for aarch64, i.e, M series chips.

The experiment is done in M1 MacBook Air:

Before this fix:
```text
(on fix_for_macos ✹)──> cargo run --bin=example --release                                                                                                                                                
   Compiling starship-battery v0.8.0
    Finished release [optimized] target(s) in 0.71s
     Running `target/release/example`
[examples/simple.rs:19] &battery = Battery {
    impl: MacOSDevice {
        source: PowerSource {
            io_object: IoObject(
                3075,
            ),
        },
    },
    vendor: None,
    model: Some(
        "bq20z451",
    ),
    serial_number: None,
    technology: Unknown,
    state: Unknown,
    capacity: 0.022820631,
    temperature: Some(
        303.69998 K^1,
    ),
    percentage: 0.8,
    cycle_count: Some(
        12,
    ),
    energy: 3494.5923 m^2 kg^1 s^-2,
    energy_full: 4368.24 m^2 kg^1 s^-2,
    energy_full_design: 191416.28 m^2 kg^1 s^-2,
    energy_rate: 0.0 m^2 kg^1 s^-3,
    voltage: 12.134001 m^2 kg^1 s^-3 A^-1,
    time_to_full: None,
    time_to_empty: None,
}
[examples/simple.rs:20] battery.state_of_charge() = 0.8
[examples/simple.rs:21] battery.state_of_health() = 0.022820631
```
Note the `energy` `energy_full` are just a few thousand joule, and `state of health` is shown as 0.02, which is impossible.

After this fix:
```text
(on fix_for_macos ✹)──> cargo run --bin=example --release                                                                                                                                          
   Compiling starship-battery v0.8.0
    Finished release [optimized] target(s) in 0.74s
     Running `target/release/example`
[examples/simple.rs:19] &battery = Battery {
    impl: MacOSDevice {
        source: PowerSource {
            io_object: IoObject(
                7427,
            ),
        },
    },
    vendor: None,
    model: Some(
        "bq20z451",
    ),
    serial_number: None,
    technology: Unknown,
    state: Unknown,
    capacity: 0.99817437,
    temperature: Some(
        303.69 K^1,
    ),
    percentage: 0.7556013,
    cycle_count: Some(
        12,
    ),
    energy: 144382.23 m^2 kg^1 s^-2,
    energy_full: 191082.56 m^2 kg^1 s^-2,
    energy_full_design: 191432.05 m^2 kg^1 s^-2,
    energy_rate: 0.0 m^2 kg^1 s^-3,
    voltage: 12.135 m^2 kg^1 s^-3 A^-1,
    time_to_full: None,
    time_to_empty: None,
}
[examples/simple.rs:20] battery.state_of_charge() = 0.7556013
[examples/simple.rs:21] battery.state_of_health() = 0.99817437
```