### PR TITLE
fix(darwin): allow fallback to non-raw key & permit errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.56.0 # MSRV
+          - 1.63.0 # MSRV
         target:
           - i686-unknown-linux-gnu
           - x86_64-unknown-linux-gnu
@@ -77,7 +77,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.56.0 # MSRV
+          - 1.63.0 # MSRV
         target:
           - x86_64-unknown-freebsd
           - aarch64-unknown-linux-gnu

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["os"]
 keywords = ["battery", "linux", "macos", "windows", "freebsd"]
 license = "ISC"
 build = "build.rs"
-rust-version = "1.56"
+rust-version = "1.63"
 
 [features]
 config-schema = ["schemars", "serde"]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Latest Version](https://img.shields.io/crates/v/starship-battery.svg)](https://crates.io/crates/starship-battery)
 [![Latest Version](https://docs.rs/starship-battery/badge.svg)](https://docs.rs/starship-battery)
 [![Build Status](https://github.com/starship/rust-battery/workflows/Continuous%20integration/badge.svg)](https://github.com/starship/rust-battery/actions?workflow=Continuous+integration)
-![Minimum rustc version](https://img.shields.io/badge/rustc-1.54+-yellow.svg)
+![Minimum rustc version](https://img.shields.io/badge/rustc-1.63+-yellow.svg)
 ![ISC licensed](https://img.shields.io/badge/license-ISC-blue.svg)
 
 > Rust crate providing cross-platform information about the notebook batteries.
@@ -44,7 +44,7 @@ might be automatically rejected by Apple based on that fact. Use it on your own 
 
 ## Install
 
-As a prerequisite, `battery` crate requires at least Rustc version **1.54** or greater.
+As a prerequisite, `battery` crate requires at least Rustc version **1.63** or greater.
 
 Add the following line into a `Cargo.toml`:
 

--- a/src/platform/windows/ffi/mod.rs
+++ b/src/platform/windows/ffi/mod.rs
@@ -88,7 +88,7 @@ impl DeviceIterator {
             return Err(io::Error::from_raw_os_error(result as i32));
         }
 
-        let mut pdidd = unsafe {
+        let pdidd = unsafe {
             winbase::LocalAlloc(minwinbase::LPTR, buf_size as basetsd::SIZE_T)
                 as setupapi::PSP_DEVICE_INTERFACE_DETAIL_DATA_W
         };

--- a/src/types/state.rs
+++ b/src/types/state.rs
@@ -13,7 +13,9 @@ use std::str;
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "lowercase")
 )]
+#[derive(Default)]
 pub enum State {
+    #[default]
     Unknown,
     Charging,
     Discharging,
@@ -54,8 +56,4 @@ impl fmt::Display for State {
     }
 }
 
-impl Default for State {
-    fn default() -> Self {
-        State::Unknown
-    }
-}
+

--- a/src/types/technology.rs
+++ b/src/types/technology.rs
@@ -6,7 +6,9 @@ use crate::Error;
 /// Possible battery technologies.
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 #[non_exhaustive]
+#[derive(Default)]
 pub enum Technology {
+    #[default]
     Unknown,
     LithiumIon,
     LeadAcid,
@@ -62,8 +64,4 @@ impl fmt::Display for Technology {
     }
 }
 
-impl Default for Technology {
-    fn default() -> Self {
-        Technology::Unknown
-    }
-}
+


### PR DESCRIPTION
Following #33:
- Allow falling back from the `*Raw*`-keys to the non-raw variants that were used before
- Don't treat failure to query the max/current capacity as an error and return 0 on failure, like with `design_capacity`.

Addresses starship/starship#5350