### PR TITLE
fix(linux): be more permissive on invalid UTF-8 file content

### DIFF
--- a/src/platform/linux/sysfs/fs.rs
+++ b/src/platform/linux/sysfs/fs.rs
@@ -94,7 +94,7 @@ pub fn scope<T: AsRef<Path>>(path: T) -> Result<Scope> {
 pub fn get_string<T: AsRef<Path>>(path: T) -> Result<Option<String>> {
     match std::fs::read(path) {
         Ok(buffer) => {
-            let mut content = String::from_utf8_lossy(buffer.as_slice()).replace(|c: char| !c.is_ascii(), "");
+            let mut content: String = String::from_utf8_lossy(buffer.as_slice()).into();
             if content.starts_with('\0') {
                 Err(io::Error::from(io::ErrorKind::InvalidData).into())
             } else {

--- a/src/platform/linux/sysfs/fs.rs
+++ b/src/platform/linux/sysfs/fs.rs
@@ -94,8 +94,7 @@ pub fn scope<T: AsRef<Path>>(path: T) -> Result<Scope> {
 pub fn get_string<T: AsRef<Path>>(path: T) -> Result<Option<String>> {
     match std::fs::read(path) {
         Ok(buffer) => {
-            let utf8_cow = String::from_utf8_lossy(buffer.as_slice()).replace(|c: char| !c.is_ascii(), "");
-            let mut content: String = utf8_cow;
+            let mut content = String::from_utf8_lossy(buffer.as_slice()).replace(|c: char| !c.is_ascii(), "");
             if content.starts_with('\0') {
                 Err(io::Error::from(io::ErrorKind::InvalidData).into())
             } else {

--- a/src/platform/linux/sysfs/fs.rs
+++ b/src/platform/linux/sysfs/fs.rs
@@ -94,7 +94,7 @@ pub fn scope<T: AsRef<Path>>(path: T) -> Result<Scope> {
 pub fn get_string<T: AsRef<Path>>(path: T) -> Result<Option<String>> {
     match std::fs::read(path) {
         Ok(buffer) => {
-            let utf8_cow = String::from_utf8_lossy(buffer.as_slice());
+            let utf8_cow = String::from_utf8_lossy(buffer.as_slice()).replace(|c: char| !c.is_ascii(), "");
             let mut content: String = utf8_cow.into();
             if content.starts_with('\0') {
                 Err(io::Error::from(io::ErrorKind::InvalidData).into())

--- a/src/platform/linux/sysfs/fs.rs
+++ b/src/platform/linux/sysfs/fs.rs
@@ -95,7 +95,7 @@ pub fn get_string<T: AsRef<Path>>(path: T) -> Result<Option<String>> {
     match std::fs::read(path) {
         Ok(buffer) => {
             let utf8_cow = String::from_utf8_lossy(buffer.as_slice()).replace(|c: char| !c.is_ascii(), "");
-            let mut content: String = utf8_cow.into();
+            let mut content: String = utf8_cow;
             if content.starts_with('\0') {
                 Err(io::Error::from(io::ErrorKind::InvalidData).into())
             } else {

--- a/src/platform/linux/sysfs/fs.rs
+++ b/src/platform/linux/sysfs/fs.rs
@@ -1,5 +1,4 @@
 use std::error;
-use std::fs::read_to_string;
 use std::io;
 use std::path::Path;
 use std::str::FromStr;
@@ -93,8 +92,10 @@ pub fn scope<T: AsRef<Path>>(path: T) -> Result<Scope> {
 /// Ok(None) - file is missing
 /// Err(_) - unable to access file for some reasons (except `NotFound` and `ENODEV`)
 pub fn get_string<T: AsRef<Path>>(path: T) -> Result<Option<String>> {
-    match read_to_string(path) {
-        Ok(mut content) => {
+    match std::fs::read(path) {
+        Ok(buffer) => {
+            let utf8_cow = String::from_utf8_lossy(buffer.as_slice());
+            let mut content: String = utf8_cow.into();
             if content.starts_with('\0') {
                 Err(io::Error::from(io::ErrorKind::InvalidData).into())
             } else {

--- a/src/platform/linux/sysfs/source.rs
+++ b/src/platform/linux/sysfs/source.rs
@@ -301,7 +301,7 @@ impl<'p> DataBuilder<'p> {
             // (real one this time), it is better just to ignore this value.
             // See: https://github.com/svartalf/rust-battery/issues/23
             match value {
-                Some(cycles) if cycles == 0 => None,
+                Some(0) => None,
                 Some(cycles) => Some(cycles),
                 None => None,
             }


### PR DESCRIPTION
Hi,
I am currently working on a port for NetBSD and maybe OpenBSD in a second time if NetBSD support is accepted at the time, and I needed to have a point of comparison.

Thus I did want to run the example on my Linux laptop and discovered that sometimes, some vendors don't use proper utf8_encoding for "batteries" models and vendors. They might use some kind of non-compatible extended ascii.

I tried to make encoding detection (with chardetng and chardet-normaliser-rs) and conversions (encoding_rs )but the amount of text is too short to have a valid result.

The thing is, I still want info on the numbers, and a panic on vendor and model name encoding stops the program, thus  not giving statistics.

Thus I decided to patch the program to bring a more permissive reading using from_utf_8_lossy, and then remove the non-ascii characters from the result not to display random bytes (as the non-ascii bytes are non-utf8 compatible anyway).

This is a take it or leave it merge request (as any pull request) but this would allow users (notably starship with battery plugin) to have battery stats even  if the vendor or model string is not nicely encoded (the rest is).

Thanks.