### PR TITLE
NetBSD support with envsys ioctl and plist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,15 +76,12 @@ jobs:
           - 1.69.0 # MSRV
         target:
           - x86_64-unknown-freebsd
-          - x86_64-unknown-netbsd
           - aarch64-unknown-linux-gnu
           - aarch64-unknown-linux-musl
           - aarch64-pc-windows-msvc
           - aarch64-apple-darwin
         include:
           - target: x86_64-unknown-freebsd
-            os: ubuntu-latest
-          - target: x86_64-unknown-netbsd
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,12 +76,15 @@ jobs:
           - 1.69.0 # MSRV
         target:
           - x86_64-unknown-freebsd
+          - x86_64-unknown-netbsd
           - aarch64-unknown-linux-gnu
           - aarch64-unknown-linux-musl
           - aarch64-pc-windows-msvc
           - aarch64-apple-darwin
         include:
           - target: x86_64-unknown-freebsd
+            os: ubuntu-latest
+          - target: x86_64-unknown-netbsd
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Starship Contributors"]
 build = "build.rs"
 categories = ["os"]
 edition = "2021"
-keywords = ["battery", "linux", "macos", "windows", "freebsd"]
+keywords = ["battery", "linux", "macos", "windows", "freebsd", "netbsd"]
 license = "ISC"
 readme = "README.md"
 repository = "https://github.com/starship/rust-battery"
@@ -36,6 +36,11 @@ winapi = { version = "~0.3.9", features = ["impl-default", "devguid", "winbase",
 [target.'cfg(any(target_os = "dragonfly", target_os = "freebsd"))'.dependencies]
 libc = "~0.2.154"
 nix = { version = "~0.28", default-features = false, features = ["ioctl"] }
+
+[target.'cfg(target_os = "netbsd")'.dependencies]
+libc = "~0.2.154"
+nix = { version = "~0.28", default-features = false, features = ["ioctl", "mman"] }
+plist = "~1.6"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ nix = { version = "~0.29.0", default-features = false, features = ["ioctl"] }
 
 [target.'cfg(target_os = "netbsd")'.dependencies]
 libc = "~0.2.154"
-nix = { version = "~0.28", default-features = false, features = ["ioctl", "mman"] }
+nix = { version = "~0.29.0", default-features = false, features = ["ioctl", "mman"] }
 plist = "~1.6"
 
 [dev-dependencies]

--- a/Cross.toml
+++ b/Cross.toml
@@ -3,3 +3,11 @@ passthrough = [
   "RUST_BACKTRACE",
   "RUST_LOG",
 ]
+
+# Fix already here https://github.com/cross-rs/cross/blob/main/docker/netbsd.sh
+# But no new release so temporary fix here instead
+# Current NetBSD target for cross-rs is 9.2
+[target.x86_64-unknown-netbsd]
+pre-build = [
+  "wget -qO- https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.2/amd64/binary/sets/base.tar.xz | tar -xJf - -C /usr/local/lib/ --strip-components 3 './usr/lib/libexecinfo.so'"
+]

--- a/Cross.toml
+++ b/Cross.toml
@@ -9,6 +9,6 @@ passthrough = [
 # Current NetBSD target for cross-rs is 9.2
 [target.x86_64-unknown-netbsd]
 pre-build = [
-  "apt-get update && apt-get --assume-yes install wget tar xz-utils",
-  "wget -qO- https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.2/amd64/binary/sets/base.tar.xz | tar -xJf - -C /usr/local/lib/ --strip-components 3 './usr/lib/libexecinfo.so'"
+  "apt-get update && apt-get --assume-yes install wget tar xz-utils file",
+  "wget -qO- https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.2/amd64/binary/sets/base.tar.xz | tar -xJf - -C /usr/local/x86_64-unknown-netbsd/lib/ --strip-components 3 --wildcards './usr/lib/libexecinfo.so*'",
 ]

--- a/Cross.toml
+++ b/Cross.toml
@@ -6,9 +6,6 @@ passthrough = [
 
 # Fix already here https://github.com/cross-rs/cross/blob/main/docker/netbsd.sh
 # But no new release so temporary fix here instead
-# Current NetBSD target for cross-rs is 9.2
+# Remove once next cross release is out
 [target.x86_64-unknown-netbsd]
-pre-build = [
-  "apt-get update && apt-get --assume-yes install wget tar xz-utils file",
-  "wget -qO- https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.2/amd64/binary/sets/base.tar.xz | tar -xJf - -C /usr/local/x86_64-unknown-netbsd/lib/ --strip-components 3 --wildcards './usr/lib/libexecinfo.so*'",
-]
+image = "ghcr.io/cross-rs/x86_64-unknown-netbsd:main"

--- a/Cross.toml
+++ b/Cross.toml
@@ -9,5 +9,6 @@ passthrough = [
 # Current NetBSD target for cross-rs is 9.2
 [target.x86_64-unknown-netbsd]
 pre-build = [
+  "apt-get update && apt-get --assume-yes install wget tar xz-utils",
   "wget -qO- https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.2/amd64/binary/sets/base.tar.xz | tar -xJf - -C /usr/local/lib/ --strip-components 3 './usr/lib/libexecinfo.so'"
 ]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ as a typed values, recalculated as necessary to be returned as a [SI measurement
 - Windows 7+
 - FreeBSD
 - DragonFlyBSD
+- NetBSD
 
 Do note that iOS implementation uses IOKit bindings, your application
 might be automatically rejected by Apple based on that fact. Use it on your own risk.
@@ -50,7 +51,7 @@ Add the following line into a `Cargo.toml`:
 
 ```toml
 [dependencies]
-battery = "0.7.8"
+battery = "0.8.3"
 ```
 
 ## Examples

--- a/examples/all.rs
+++ b/examples/all.rs
@@ -1,0 +1,34 @@
+extern crate starship_battery as battery;
+
+// use std::io;
+use std::thread;
+use std::time::Duration;
+use std::vec::Vec;
+
+use battery::Battery;
+
+fn main() -> battery::Result<()> {
+    let manager = battery::Manager::new()?;
+    let mut vc: Vec<Battery> = Vec::<Battery>::new();
+
+    let iter = manager.batteries()?;
+
+    for bat in iter {
+        vc.push(match bat {
+            Ok(battery) => battery,
+            Err(e) => {
+                eprintln!("Unable to access battery information");
+                return Err(e);
+            }
+        })
+    }
+
+    loop {
+        for bat in &mut vc {
+            println!("{:?}", bat);
+            thread::sleep(Duration::from_secs(1));
+            manager.refresh(bat)?;
+        }
+        println!("Back to the beginning")
+    }
+}

--- a/examples/all.rs
+++ b/examples/all.rs
@@ -1,6 +1,5 @@
 extern crate starship_battery as battery;
 
-// use std::io;
 use std::thread;
 use std::time::Duration;
 use std::vec::Vec;

--- a/examples/oneshot.rs
+++ b/examples/oneshot.rs
@@ -1,0 +1,21 @@
+extern crate starship_battery as battery;
+
+use std::io;
+
+fn main() -> battery::Result<()> {
+    let manager = battery::Manager::new()?;
+    let battery = match manager.batteries()?.next() {
+        Some(Ok(battery)) => battery,
+        Some(Err(e)) => {
+            eprintln!("Unable to access battery information");
+            return Err(e);
+        }
+        None => {
+            eprintln!("Unable to find any batteries");
+            return Err(io::Error::from(io::ErrorKind::NotFound).into());
+        }
+    };
+
+    println!("{:?}", battery);
+    Ok(())
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -78,7 +78,7 @@ impl From<io::Error> for Error {
     }
 }
 
-#[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd"))]
 mod nix_impl {
     use std::io;
 
@@ -90,6 +90,17 @@ mod nix_impl {
                 source: io::Error::from_raw_os_error(errno as i32),
                 description: Some(errno.desc().into()),
             }
+        }
+    }
+}
+
+#[cfg(target_os = "netbsd")]
+mod plist_impl {
+    use super::Error;
+
+    impl From<plist::Error> for Error {
+        fn from(e: plist::Error) -> Self {
+            e.into()
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 //! * Windows 7+
 //! * FreeBSD
 //! * DragonFlyBSD
+//! * NetBSD
 //!
 //! ## Examples
 //!
@@ -32,9 +33,12 @@ extern crate cfg_if;
 #[macro_use]
 extern crate winapi;
 
-#[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd"))]
 #[macro_use]
 extern crate nix;
+
+#[cfg(target_os = "netbsd")]
+extern crate plist;
 
 mod types;
 #[macro_use]

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -23,6 +23,12 @@ cfg_if! {
         pub type Manager = freebsd::IoCtlManager;
         pub type Iterator = freebsd::IoCtlIterator;
         pub type Device = freebsd::IoCtlDevice;
+     } else if #[cfg(target_os = "netbsd")] {
+        mod netbsd;
+
+        pub type Manager = netbsd::SysMonManager;
+        pub type Iterator = netbsd::SysMonIterator;
+        pub type Device = netbsd::SysMonDevice;
     } else {
         compile_error!("Support for this target OS is not implemented yet!\n \
             You may want to create an issue: https://github.com/starship/rust-battery/issues/new");

--- a/src/platform/netbsd/device.rs
+++ b/src/platform/netbsd/device.rs
@@ -1,0 +1,268 @@
+use crate::platform::traits::BatteryDevice;
+use crate::plist;
+use crate::units::{ElectricPotential, Energy, Power, ThermodynamicTemperature};
+use crate::{Error, Result};
+use crate::{State, Technology};
+
+use super::utils::{AsResult, GetResult};
+
+// It is assumed that devices use the same unit for the same type of measures.
+// In other words it is assumed that if a device exposes energy_full is in ampere hours, it  won't
+// report energy_full_design in watt hours.
+
+// Only tested with an acpibat battery.
+
+#[derive(Debug, Default)]
+pub struct EnvSysDevice<'a> {
+    name: String,
+    energy: u64,
+    energy_full: u64,
+    energy_full_design: u64,
+    charge_rate: i64,
+    discharge_rate: i64,
+    voltage: u64,
+    design_voltage: u64,
+    charging: i64,
+    punit: &'a str,
+    eunit: &'a str,
+}
+
+impl<'a> EnvSysDevice<'a> {
+    pub fn new(name: String, sensor: &'a plist::Value) -> Result<Self> {
+        let sensor_slice = sensor.as_rslice()?;
+        let mut data = Self {
+            name,
+            ..Self::default()
+        };
+
+        let mut status: bool = true;
+
+        // Man 4 envsys from NetBSD 10 tells the last one is a "special dictionary"
+        // for device properties.
+
+        // We still want our iterator to start from the beginning.
+        // Thus we need to access the last element before iterating.
+
+        if sensor_slice
+            .last()
+            .ok_or(Error::invalid_data("Cannot read sensor property"))?
+            .get_rdict("device-properties")?
+            .get_rstring("device-class")?
+            != "battery"
+        {
+            return Err(Error::invalid_data("Not a valid battery"));
+        }
+
+        // Loop as nothing tells the slice will be populated in order outside of the last one.
+        for attr_res in sensor_slice {
+            match attr_res.get_rstring("description") {
+                Ok("present") => match Self::val_cur_value(attr_res)? {
+                    1 => continue,
+                    _ => return Err(Error::not_found("Battery absent")),
+                },
+                Ok("design voltage") => data.design_voltage = Self::val_cur_value(attr_res)?,
+                Ok("voltage") => data.voltage = Self::val_cur_value(attr_res)?,
+                Ok("design cap") => {
+                    data.energy_full_design = Self::val_cur_value(attr_res)?;
+                    data.eunit = attr_res.get_rstring("type")?;
+                }
+                Ok("last full cap") => data.energy_full = Self::val_cur_value(attr_res)?,
+                Ok("charge") => {
+                    // max-value in the xml is assumed == to last full cap.
+                    if Self::validate(attr_res)?.get_rbool("want-percentage")? == false {
+                        return Err(Error::invalid_data("Not a valid battery"));
+                    }
+                    data.energy = attr_res.get_ru64("cur-value")?;
+                }
+                // No validate on charge and discharge rate, we will look at charging to determine that.
+                Ok("charge rate") => {
+                    data.charge_rate = attr_res.get_ri64("cur-value")?;
+                    data.punit = attr_res.get_rstring("type")?;
+                }
+                Ok("discharge rate") => {
+                    data.discharge_rate = attr_res.get_ri64("cur-value")?;
+                    // Sometimes battery can have problems.
+                    // Read that in https://github.com/NetBSD/src/blob/trunk/sys/dev/acpi/acpi_bat.c line 555.
+                    status = attr_res.get_rstring("state")? == "invalid";
+                }
+                Ok("charging") => data.charging = Self::validate(attr_res)?.get_ri64("cur-value")?,
+                Ok(_) => continue,
+                Err(e) => match attr_res.get_rdict("device-properties") {
+                    Ok(_) => continue,
+                    Err(_) => return Err(e),
+                },
+            }
+        }
+
+        if data.charging == 0 && status {
+            data.charging = -1;
+        }
+
+        Ok(data)
+    }
+
+    fn validate(value: &plist::Value) -> Result<&plist::Value> {
+        match value.get_rstring("state")? {
+            "valid" => Ok(value),
+            _ => Err(Error::invalid_data("Invalid section")),
+        }
+    }
+
+    fn val_cur_value(value: &plist::Value) -> Result<u64> {
+        Self::validate(value)?.get_ru64("cur-value")
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct SysMonDevice {
+    pub name: String,
+
+    energy: Energy,
+    energy_full: Energy,
+    energy_full_design: Energy,
+    energy_rate: Power,
+    state: State,
+    voltage: ElectricPotential,
+}
+
+impl SysMonDevice {
+    // data.name should match the SysMonDevice object.name already
+    pub fn new(data: EnvSysDevice) -> Result<Self> {
+        let mut bat = Self { ..Default::default() };
+
+        match bat.refresh(data) {
+            Ok(_) => Ok(bat),
+            Err(e) => Err(e),
+        }
+    }
+
+    // data.name should match the SysMonDevice object.name already
+    pub fn refresh(&mut self, data: EnvSysDevice) -> Result<()> {
+        let design_voltage = microvolt!(data.design_voltage);
+
+        self.name = data.name;
+        self.voltage = microvolt!(data.voltage);
+
+        // Cound not test Watt hour, it is an assumption based on doc
+        match data.eunit {
+            "Ampere hour" => {
+                self.energy = microampere_hour!(data.energy) * design_voltage;
+                self.energy_full = microampere_hour!(data.energy_full) * design_voltage;
+                self.energy_full_design = microampere_hour!(data.energy_full_design) * design_voltage;
+            }
+            "Watt hour" => {
+                self.energy = microwatt_hour!(data.energy);
+                self.energy_full = microwatt_hour!(data.energy_full);
+                self.energy_full_design = microwatt_hour!(data.energy_full_design);
+            }
+            _ => return Err(Error::invalid_data("Unit not supported")),
+        }
+
+        // Cound not test Watt, it is an assumption based on doc.
+        // Beware NetBSD needs some delay updating fields properly.
+        // In tests, the refresh timeout is not always respected.
+        self.energy_rate = match (data.charging, data.punit) {
+            (1, "Ampere") => microampere!(data.charge_rate.abs()) * design_voltage,
+            (1, "Watts") => microwatt!(data.charge_rate.abs()),
+            (0, "Ampere") => microampere!(data.discharge_rate.abs()) * design_voltage,
+            (0, "Watts") => microwatt!(data.discharge_rate.abs()),
+            // The battery has a problem in case of -1, set 0,
+            (-1, _) => microwatt!(0),
+            _ => return Err(Error::invalid_data("Unit not supported or invalid state")),
+        };
+
+        if self.energy >= self.energy_full {
+            self.state = State::Full;
+        } else if self.energy == microwatt_hour!(0) {
+            // Probably won't ever happen or maybe charging after completely empty battery.
+            // NetBSD provides warning and critical capacity warning,
+            // but this lib does not implement such states.
+            self.state = State::Empty;
+        } else {
+            self.state = match data.charging {
+                1 => State::Charging,
+                0 => State::Discharging,
+                _ => State::Unknown,
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// Trait wants the following data.
+// NetBSD (10 at the time of the implementation) does not provide all data.
+// Thankfully missing fields are Options.
+
+// energy                charge (type for unit)
+// energy_full           last full cap
+// energy_full_design    design cap
+// energy_rate           charge rate or discharge rate.... (state valid or not)
+// voltage               voltage
+// state                 Can be determined
+// technology            N/A
+// temperature           N/A
+// cycle_count           N/A
+// vendor                N/A
+// model                 N/A
+// serial_number         N/A
+// time_to_full          Automatically calculated needs energy_rate and energy and energy_full
+// time_to_empty         Automatically calculated needs energy_rate and energy
+// state_of_health       Automatically calculated needs energy_full and energy_full_design
+// state_of_charge       Automatically calculated needs energy and energy_full
+
+// NetBSD provides some sort of state_of_health with baterry-capacity and charge_state
+// but this library provides its own methods of calculation so using them for library consistency.
+
+// Thanks to unitedbsd.com community for this thread.
+// https://www.unitedbsd.com/d/486-querying-battery-information-wo-envstat/6
+
+impl BatteryDevice for SysMonDevice {
+    fn energy(&self) -> Energy {
+        self.energy
+    }
+
+    fn energy_full(&self) -> Energy {
+        self.energy_full
+    }
+
+    fn energy_full_design(&self) -> Energy {
+        self.energy_full_design
+    }
+
+    fn energy_rate(&self) -> Power {
+        self.energy_rate
+    }
+
+    fn state(&self) -> State {
+        self.state
+    }
+
+    fn voltage(&self) -> ElectricPotential {
+        self.voltage
+    }
+
+    fn temperature(&self) -> Option<ThermodynamicTemperature> {
+        None
+    }
+
+    fn vendor(&self) -> Option<&str> {
+        None
+    }
+
+    fn model(&self) -> Option<&str> {
+        None
+    }
+
+    fn serial_number(&self) -> Option<&str> {
+        None
+    }
+
+    fn technology(&self) -> Technology {
+        Technology::Unknown
+    }
+
+    fn cycle_count(&self) -> Option<u32> {
+        None
+    }
+}

--- a/src/platform/netbsd/device.rs
+++ b/src/platform/netbsd/device.rs
@@ -69,7 +69,7 @@ impl<'a> EnvSysDevice<'a> {
                 Ok("last full cap") => data.energy_full = Self::val_cur_value(attr_res)?,
                 Ok("charge") => {
                     // max-value in the xml is assumed == to last full cap.
-                    if Self::validate(attr_res)?.get_rbool("want-percentage")? == false {
+                    if !Self::validate(attr_res)?.get_rbool("want-percentage")? {
                         return Err(Error::invalid_data("Not a valid battery"));
                     }
                     data.energy = attr_res.get_ru64("cur-value")?;

--- a/src/platform/netbsd/device.rs
+++ b/src/platform/netbsd/device.rs
@@ -85,7 +85,9 @@ impl<'a> EnvSysDevice<'a> {
                     // Read that in https://github.com/NetBSD/src/blob/trunk/sys/dev/acpi/acpi_bat.c line 555.
                     status = attr_res.get_rstring("state")? == "invalid";
                 }
-                Ok("charging") => data.charging = Self::validate(attr_res)?.get_ri64("cur-value")?,
+                Ok("charging") => {
+                    data.charging = Self::validate(attr_res)?.get_ri64("cur-value")?
+                }
                 Ok(_) => continue,
                 Err(e) => match attr_res.get_rdict("device-properties") {
                     Ok(_) => continue,
@@ -128,7 +130,9 @@ pub struct SysMonDevice {
 impl SysMonDevice {
     // data.name should match the SysMonDevice object.name already
     pub fn new(data: EnvSysDevice) -> Result<Self> {
-        let mut bat = Self { ..Default::default() };
+        let mut bat = Self {
+            ..Default::default()
+        };
 
         match bat.refresh(data) {
             Ok(_) => Ok(bat),
@@ -148,7 +152,8 @@ impl SysMonDevice {
             "Ampere hour" => {
                 self.energy = microampere_hour!(data.energy) * design_voltage;
                 self.energy_full = microampere_hour!(data.energy_full) * design_voltage;
-                self.energy_full_design = microampere_hour!(data.energy_full_design) * design_voltage;
+                self.energy_full_design =
+                    microampere_hour!(data.energy_full_design) * design_voltage;
             }
             "Watt hour" => {
                 self.energy = microwatt_hour!(data.energy);

--- a/src/platform/netbsd/iterator.rs
+++ b/src/platform/netbsd/iterator.rs
@@ -37,11 +37,6 @@ impl Iterator for SysMonIterator {
 
         None
     }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        // Can't predict number of batteries so keep default.
-        (0, None)
-    }
 }
 
 impl BatteryIterator for SysMonIterator {

--- a/src/platform/netbsd/iterator.rs
+++ b/src/platform/netbsd/iterator.rs
@@ -1,0 +1,67 @@
+use crate::plist::dictionary::IntoIter;
+
+use crate::platform::traits::BatteryIterator;
+use crate::Result;
+
+use super::device::EnvSysDevice;
+use super::{sysmon::get_system_envsys_plist, SysMonDevice, SysMonManager};
+
+use std::fmt;
+use std::sync::Arc;
+
+pub struct SysMonIterator {
+    #[allow(dead_code)]
+    manager: Arc<SysMonManager>,
+    iter: IntoIter,
+}
+
+impl Iterator for SysMonIterator {
+    type Item = Result<SysMonDevice>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        for (key, sensor) in &mut self.iter {
+            // Iterator over any kind of sensors so "Not a valid battery" should just continue.
+            // Same for battery absent as it does not mean the battery is invalid, just absent.
+            match EnvSysDevice::new(key, &sensor) {
+                Ok(envsysdev) => match SysMonDevice::new(envsysdev) {
+                    Ok(bat) => return Some(Ok(bat)),
+                    Err(e) => return Some(Err(e)),
+                },
+                Err(e) => match e.to_string().as_str() {
+                    "Not a valid battery" => continue,
+                    "Battery absent" => continue,
+                    _ => return Some(Err(e)),
+                },
+            }
+        }
+
+        None
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // Can't predict number of batteries so keep default.
+        (0, None)
+    }
+}
+
+impl BatteryIterator for SysMonIterator {
+    type Manager = SysMonManager;
+    type Device = SysMonDevice;
+
+    fn new(manager: Arc<Self::Manager>) -> Result<Self> {
+        Ok(Self {
+            manager,
+            iter: get_system_envsys_plist()?.into_iter(),
+        })
+    }
+}
+
+impl fmt::Debug for SysMonIterator {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "SysMonIterator {{ manager: {:?}, Iter: 'Does not implement Debug'}}",
+            self.manager
+        )
+    }
+}

--- a/src/platform/netbsd/manager.rs
+++ b/src/platform/netbsd/manager.rs
@@ -1,0 +1,29 @@
+use crate::platform::traits::BatteryManager;
+use crate::{Error, Result};
+
+use super::device::EnvSysDevice;
+use super::sysmon::get_system_envsys_plist;
+use super::{SysMonDevice, SysMonIterator};
+
+#[derive(Debug)]
+pub struct SysMonManager;
+
+impl BatteryManager for SysMonManager {
+    type Iterator = SysMonIterator;
+
+    fn new() -> Result<Self> {
+        Ok(Self {})
+    }
+
+    fn refresh(&self, device: &mut SysMonDevice) -> Result<()> {
+        // Sadly NetBSD only have one ioctl that retrieves ALL batteries' data.
+        // This means we have to get all data to update only one device as
+        // we can't just assume the user will want to update all devices at the same time.
+        let envsys = get_system_envsys_plist()?;
+
+        match envsys.get(device.name.as_str()) {
+            Some(sensor) => device.refresh(EnvSysDevice::new(device.name.to_owned(), &sensor)?),
+            None => Err(Error::not_found("Could not refresh battery")),
+        }
+    }
+}

--- a/src/platform/netbsd/manager.rs
+++ b/src/platform/netbsd/manager.rs
@@ -22,7 +22,7 @@ impl BatteryManager for SysMonManager {
         let envsys = get_system_envsys_plist()?;
 
         match envsys.get(device.name.as_str()) {
-            Some(sensor) => device.refresh(EnvSysDevice::new(device.name.to_owned(), &sensor)?),
+            Some(sensor) => device.refresh(EnvSysDevice::new(device.name.to_owned(), sensor)?),
             None => Err(Error::not_found("Could not refresh battery")),
         }
     }

--- a/src/platform/netbsd/mod.rs
+++ b/src/platform/netbsd/mod.rs
@@ -1,0 +1,9 @@
+mod device;
+mod iterator;
+mod manager;
+mod sysmon;
+mod utils;
+
+pub use self::device::SysMonDevice;
+pub use self::iterator::SysMonIterator;
+pub use self::manager::SysMonManager;

--- a/src/platform/netbsd/sysmon.rs
+++ b/src/platform/netbsd/sysmon.rs
@@ -54,7 +54,7 @@ pub fn get_system_envsys_plist() -> Result<plist::Dictionary, Error> {
     })?;
 
     unsafe {
-        // The netbsd libprog says ioctl returned mmap'ed memory that must be munmap'ed.
+        // The netbsd libprop says ioctl returned mmap'ed memory that must be munmap'ed.
         // https://www.unitedbsd.com/d/486-querying-battery-information-wo-envstat/4
         // https://github.com/NetBSD/src/blob/trunk/common/lib/libprop/prop_kern.c
         // Also unwrap is fine as we already check for non_null above.

--- a/src/platform/netbsd/sysmon.rs
+++ b/src/platform/netbsd/sysmon.rs
@@ -1,0 +1,68 @@
+use std::fs;
+use std::os::fd::AsRawFd;
+use std::ptr::{addr_of_mut, null_mut, NonNull};
+use std::slice;
+
+use libc::{c_void, size_t};
+
+use crate::nix::sys::mman::munmap;
+use crate::plist;
+use crate::Error;
+
+// https://man.netbsd.org/ioctl.9
+// man ioctlprint
+// ENVSYS_GETDICTIONARY _IOWR('E', 0, struct plistref)  0xc0104500
+// https://github.com/NetBSD/src/blob/trunk/common/include/prop/plistref.h#L43
+
+const SYSMON_PATH: &str = "/dev/sysmon";
+
+// ioctl is rw even if we only need read as per system definition
+ioctl_readwrite!(envsys_getdictionary, b'E', 0, Plistref);
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct Plistref {
+    pref_plist: *mut u8,
+    pref_len: size_t,
+}
+
+impl Default for Plistref {
+    fn default() -> Self {
+        Self {
+            pref_plist: null_mut(),
+            pref_len: 0,
+        }
+    }
+}
+
+pub fn get_system_envsys_plist() -> Result<plist::Dictionary, Error> {
+    let mut plist_ref: Plistref = Plistref::default();
+
+    let file = fs::OpenOptions::new().read(true).open(SYSMON_PATH)?;
+    let fd = file.as_raw_fd();
+
+    unsafe {
+        envsys_getdictionary(fd, addr_of_mut!(plist_ref))?;
+    }
+
+    if plist_ref.pref_len == 0 || plist_ref.pref_plist == null_mut() {
+        return Err(Error::invalid_data("Invalid result of EnvSys ioctl"));
+    }
+
+    let dict = plist::from_bytes(unsafe {
+        slice::from_raw_parts(plist_ref.pref_plist, plist_ref.pref_len)
+    })?;
+
+    unsafe {
+        // The netbsd libprog says ioctl returned mmap'ed memory that must be munmap'ed.
+        // https://www.unitedbsd.com/d/486-querying-battery-information-wo-envstat/4
+        // https://github.com/NetBSD/src/blob/trunk/common/lib/libprop/prop_kern.c
+        // Also unwrap is fine as we already check for non_null above.
+        munmap(
+            NonNull::new(plist_ref.pref_plist as *mut c_void).unwrap(),
+            plist_ref.pref_len,
+        )?;
+    }
+
+    Ok(dict)
+}

--- a/src/platform/netbsd/sysmon.rs
+++ b/src/platform/netbsd/sysmon.rs
@@ -45,7 +45,7 @@ pub fn get_system_envsys_plist() -> Result<plist::Dictionary, Error> {
         envsys_getdictionary(fd, addr_of_mut!(plist_ref))?;
     }
 
-    if plist_ref.pref_len == 0 || plist_ref.pref_plist == null_mut() {
+    if plist_ref.pref_len == 0 || plist_ref.pref_plist.is_null() {
         return Err(Error::invalid_data("Invalid result of EnvSys ioctl"));
     }
 

--- a/src/platform/netbsd/utils.rs
+++ b/src/platform/netbsd/utils.rs
@@ -1,0 +1,111 @@
+use crate::plist;
+use crate::{Error, Result};
+
+// This file contains an extention trait because plist provides options and not results.
+// This is here only to bring better readability into device.rs by avoiding chains of conversions.
+
+pub trait AsResult {
+    fn as_rdict(&self) -> Result<&plist::Dictionary>;
+    fn as_rslice(&self) -> Result<&[plist::Value]>;
+}
+
+impl AsResult for plist::Value {
+    #[inline]
+    fn as_rdict(&self) -> Result<&plist::Dictionary> {
+        self.as_dictionary()
+            .ok_or(Error::invalid_data("Cannot convert value to Dict"))
+    }
+
+    #[inline]
+    fn as_rslice(&self) -> Result<&[plist::Value]> {
+        Ok(self
+            .as_array()
+            .ok_or(Error::invalid_data("Cannot convert value to slice"))?
+            .as_slice())
+    }
+}
+
+pub trait GetResult {
+    fn get_rdict(&self, key: &str) -> Result<&plist::Dictionary>;
+    fn get_ru64(&self, key: &str) -> Result<u64>;
+    fn get_ri64(&self, key: &str) -> Result<i64>;
+    fn get_rbool(&self, key: &str) -> Result<bool>;
+    fn get_rslice(&self, key: &str) -> Result<&[plist::Value]>;
+    fn get_rstring(&self, key: &str) -> Result<&str>;
+}
+
+impl GetResult for plist::Dictionary {
+    #[inline]
+    fn get_rdict(&self, key: &str) -> Result<&plist::Dictionary> {
+        self.get(key)
+            .ok_or(Error::invalid_data("Cannot convert value to Dict"))?
+            .as_rdict()
+    }
+
+    #[inline]
+    fn get_ru64(&self, key: &str) -> Result<u64> {
+        self.get(key)
+            .and_then(|x| x.as_unsigned_integer())
+            .ok_or(Error::invalid_data("Cannot convert value to u64"))
+    }
+
+    #[inline]
+    fn get_ri64(&self, key: &str) -> Result<i64> {
+        self.get(key)
+            .and_then(|x| x.as_signed_integer())
+            .ok_or(Error::invalid_data("Cannot convert value to i64"))
+    }
+
+    #[inline]
+    fn get_rbool(&self, key: &str) -> Result<bool> {
+        self.get(key)
+            .and_then(|x| x.as_boolean())
+            .ok_or(Error::invalid_data("Cannot convert value to bool"))
+    }
+
+    #[inline]
+    fn get_rslice(&self, key: &str) -> Result<&[plist::Value]> {
+        self.get(key)
+            .ok_or(Error::invalid_data("Cannot convert value to slice"))?
+            .as_rslice()
+    }
+
+    #[inline]
+    fn get_rstring(&self, key: &str) -> Result<&str> {
+        self.get(key)
+            .and_then(|x| x.as_string())
+            .ok_or(Error::invalid_data("Cannot convert value to string"))
+    }
+}
+
+impl GetResult for plist::Value {
+    #[inline]
+    fn get_rdict(&self, key: &str) -> Result<&plist::Dictionary> {
+        self.as_rdict()?.get_rdict(key)
+    }
+
+    #[inline]
+    fn get_ru64(&self, key: &str) -> Result<u64> {
+        self.as_rdict()?.get_ru64(key)
+    }
+
+    #[inline]
+    fn get_ri64(&self, key: &str) -> Result<i64> {
+        self.as_rdict()?.get_ri64(key)
+    }
+
+    #[inline]
+    fn get_rbool(&self, key: &str) -> Result<bool> {
+        self.as_rdict()?.get_rbool(key)
+    }
+
+    #[inline]
+    fn get_rslice(&self, key: &str) -> Result<&[plist::Value]> {
+        self.as_rdict()?.get_rslice(key)
+    }
+
+    #[inline]
+    fn get_rstring(&self, key: &str) -> Result<&str> {
+        self.as_rdict()?.get_rstring(key)
+    }
+}


### PR DESCRIPTION
New examples, simple.rs only refreshed the first battery, and this does not help checking for iterator validity for development, all.rs solves the problem. The example oneshot.rs is just for comfort avoiding loop.

NetBSD exposes battery information through one ioctl so for now we have to "waste" resource getting all sensors info for each single battery refresh. We can't assume the library user will want to refresh all bateries at the same time even if 90% of time it will probably be.

The result of the ioctl is a plist (apple format) that needs to be parsed and accessed.

The plist library only uses options, so this is the reason for utils.rs. These are all oneline functions to reduce the lenght of chains in the netbsd platform device.rs file.

NetBSD does not expose battery vendor, model, technology, cycle among other things for now, but these are optional.

Got inspiration from the FreeBSD port regarding having a better understanding on how the library works.

Thanks to unitedbsd.com community for the guidance, and shout out to https://github.com/distatus/battery/blob/master/battery_netbsd.go as well as the NetBSD devs for the great man pages and the clear code allowing to read what happens for undocumented things.

My code has comments for anyone interested to understand what happens.

By lack of hardware (only tested on one laptop), I couldn't test some specific things such as cases where battery use the watt units instead of ampere. I implemented that with the NetBSD man pages and inspiration from the FreeBSD port.

This port was only tested with a battery using the acpibat driver, but this should work with any battery that follow the same standard in the the sysmon_envsys format and fields.