### PR TITLE
fix(darwin): prefer non-raw values for state_of_charge

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -20,6 +20,7 @@ allow = [
   "Apache-2.0",
   "ISC",
   "MIT",
+  "Unicode-3.0",
   "Unicode-DFS-2016",
 ]
 confidence-threshold = 0.8

--- a/src/platform/darwin/iokit/power_source.rs
+++ b/src/platform/darwin/iokit/power_source.rs
@@ -48,6 +48,8 @@ pub struct InstantData {
     design_capacity: Option<ElectricCharge>,
     max_capacity: Option<ElectricCharge>,
     current_capacity: Option<ElectricCharge>,
+    max_capacity_raw: Option<ElectricCharge>,
+    current_capacity_raw: Option<ElectricCharge>,
     temperature: Option<ThermodynamicTemperature>,
     cycle_count: Option<u32>,
     time_remaining: Option<Time>,
@@ -64,11 +66,16 @@ impl InstantData {
             design_capacity: Self::get_u32(props, DESIGN_CAPACITY_KEY)
                 .ok()
                 .map(|capacity| milliampere_hour!(capacity)),
-            max_capacity: Self::get_u32(props, MAX_CAPACITY_KEY_RAW)
-                .or_else(|_| Self::get_u32(props, MAX_CAPACITY_KEY))
+            max_capacity: Self::get_u32(props, MAX_CAPACITY_KEY)
                 .ok()
                 .map(|capacity| milliampere_hour!(capacity)),
-            current_capacity: Self::get_u32(props, CURRENT_CAPACITY_KEY_RAW)
+            current_capacity: Self::get_u32(props, CURRENT_CAPACITY_KEY)
+                .ok()
+                .map(|capacity| milliampere_hour!(capacity)),
+            max_capacity_raw: Self::get_u32(props, MAX_CAPACITY_KEY_RAW)
+                .ok()
+                .map(|capacity| milliampere_hour!(capacity)),
+            current_capacity_raw: Self::get_u32(props, CURRENT_CAPACITY_KEY_RAW)
                 .or_else(|_| Self::get_u32(props, CURRENT_CAPACITY_KEY))
                 .ok()
                 .map(|capacity| milliampere_hour!(capacity)),
@@ -214,6 +221,20 @@ impl DataSource for PowerSource {
 
     fn design_capacity(&self) -> ElectricCharge {
         self.data.design_capacity.unwrap_or_default()
+    }
+
+    fn max_capacity_raw(&self) -> ElectricCharge {
+        self.data
+            .max_capacity_raw
+            .or(self.data.max_capacity)
+            .unwrap_or_default()
+    }
+
+    fn current_capacity_raw(&self) -> ElectricCharge {
+        self.data
+            .current_capacity_raw
+            .or(self.data.current_capacity)
+            .unwrap_or_default()
     }
 
     fn max_capacity(&self) -> ElectricCharge {

--- a/src/platform/darwin/tests.rs
+++ b/src/platform/darwin/tests.rs
@@ -57,7 +57,15 @@ impl DataSource for TestDataSource {
         milliampere_hour!(self.max_capacity)
     }
 
+    fn max_capacity_raw(&self) -> ElectricCharge {
+        milliampere_hour!(self.max_capacity)
+    }
+
     fn current_capacity(&self) -> ElectricCharge {
+        milliampere_hour!(self.current_capacity)
+    }
+
+    fn current_capacity_raw(&self) -> ElectricCharge {
         milliampere_hour!(self.current_capacity)
     }
 

--- a/src/platform/darwin/traits.rs
+++ b/src/platform/darwin/traits.rs
@@ -38,8 +38,14 @@ pub trait DataSource: Debug + 'static {
     /// kIOPMPSMaxCapacityKey, mAh
     fn max_capacity(&self) -> ElectricCharge;
 
+    /// Returns raw value if available, otherwise uses the regular one.
+    fn max_capacity_raw(&self) -> ElectricCharge;
+
     /// kIOPMPSCurrentCapacityKey, mAh
     fn current_capacity(&self) -> ElectricCharge;
+
+    /// Returns raw value if available, otherwise uses the regular one.
+    fn current_capacity_raw(&self) -> ElectricCharge;
 
     /// kIOPMPSBatteryTemperatureKey
     fn temperature(&self) -> Option<ThermodynamicTemperature>;
@@ -96,8 +102,16 @@ where
         (**self).max_capacity()
     }
 
+    fn max_capacity_raw(&self) -> ElectricCharge {
+        (**self).max_capacity_raw()
+    }
+
     fn current_capacity(&self) -> ElectricCharge {
         (**self).current_capacity()
+    }
+
+    fn current_capacity_raw(&self) -> ElectricCharge {
+        (**self).current_capacity_raw()
     }
 
     fn temperature(&self) -> Option<ThermodynamicTemperature> {


### PR DESCRIPTION
The `*Raw` keys for current/max capacity may not match physical expectations, but they are likely more accurate for charge ratio calculations. Thus, this PR updates the coded to prefer these for `state_of_charge()`.

Closes #34