### PR TITLE
add support for "not charging" from status on linux

### DIFF
--- a/src/types/state.rs
+++ b/src/types/state.rs
@@ -21,6 +21,7 @@ pub enum State {
     Discharging,
     Empty,
     Full,
+    LimitedFull, // when charge limit is set and the battery already reached the limitation
 }
 
 impl str::FromStr for State {
@@ -28,7 +29,6 @@ impl str::FromStr for State {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // TODO: Support strings that starts with `\0`
-        // TODO: Support `not charging` value
         // Ref: `up_device_supply_get_state` function at
         //https://gitlab.freedesktop.org/upower/upower/blob/master/src/linux/up-device-supply.c#L452
         match s {
@@ -37,6 +37,7 @@ impl str::FromStr for State {
             _ if s.eq_ignore_ascii_case("Full") => Ok(State::Full),
             _ if s.eq_ignore_ascii_case("Charging") => Ok(State::Charging),
             _ if s.eq_ignore_ascii_case("Discharging") => Ok(State::Discharging),
+            _ if s.eq_ignore_ascii_case("Not Charging") => Ok(State::LimitedFull),
             _ => Err(io::Error::from(io::ErrorKind::InvalidData)),
         }
     }
@@ -49,6 +50,7 @@ impl fmt::Display for State {
             State::Charging => "charging",
             State::Discharging => "discharging",
             State::Empty => "empty",
+            State::LimitedFull => "not charging",
             State::Full => "full",
         };
 

--- a/src/types/state.rs
+++ b/src/types/state.rs
@@ -50,7 +50,7 @@ impl fmt::Display for State {
             State::Charging => "charging",
             State::Discharging => "discharging",
             State::Empty => "empty",
-            State::Paused => "not charging",
+            State::Paused => "paused",
             State::Full => "full",
         };
 

--- a/src/types/state.rs
+++ b/src/types/state.rs
@@ -21,7 +21,7 @@ pub enum State {
     Discharging,
     Empty,
     Full,
-    LimitedFull, // when charge limit is set and the battery already reached the limitation
+    Paused, // when charge limit is set and the battery already reached the limitation
 }
 
 impl str::FromStr for State {
@@ -37,7 +37,7 @@ impl str::FromStr for State {
             _ if s.eq_ignore_ascii_case("Full") => Ok(State::Full),
             _ if s.eq_ignore_ascii_case("Charging") => Ok(State::Charging),
             _ if s.eq_ignore_ascii_case("Discharging") => Ok(State::Discharging),
-            _ if s.eq_ignore_ascii_case("Not Charging") => Ok(State::LimitedFull),
+            _ if s.eq_ignore_ascii_case("Not Charging") => Ok(State::Paused),
             _ => Err(io::Error::from(io::ErrorKind::InvalidData)),
         }
     }
@@ -50,7 +50,7 @@ impl fmt::Display for State {
             State::Charging => "charging",
             State::Discharging => "discharging",
             State::Empty => "empty",
-            State::LimitedFull => "not charging",
+            State::Paused => "not charging",
             State::Full => "full",
         };
 


### PR DESCRIPTION
Some laptops support "charge limit" to make battery stop charging at capacity percentage less than 100%, to make the battery lives longer. When the laptop has set the limit and the battery has reached the limit, value of `/sys/class/power_supply/BAT1/status` will be "Not charging".

Thus, I add `LimitedFull` state on` types/State`, to indicate this state.  I also made changes on `from_str` and `imple Display` of `State`.