### PR TITLE
fix: Bump plist to ~1.10.0 on netbsd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ nix = { version = "~0.31.3", default-features = false, features = ["ioctl"] }
 [target.'cfg(target_os = "netbsd")'.dependencies]
 libc = "~0.2.186"
 nix = { version = "~0.31.3", default-features = false, features = ["ioctl", "mman"] }
-plist = "~1.9.0"
+plist = "~1.10.0"
 
 [dev-dependencies]
 approx = "0.5.1"


### PR DESCRIPTION
Bumps the netbsd `plist` requirement from `~1.9.0` to `~1.10.0`.

plist 1.10.0 moved from quick-xml 0.39 to quick-xml 0.41, which resolves [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194) and [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195). While `~1.9.0` caps at `<1.10.0`, any downstream that shares a lockfile with rust-battery is pinned to the vulnerable quick-xml.

The netbsd backend only uses stable plist 1.x `Value`/`Dictionary` accessors (via the local `AsResult` trait), so 1.10.0 is a drop-in.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/starship/rust-battery/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

